### PR TITLE
fix: remove `--depth 1` flag from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG flutterVersion=stable
 
 ADD https://api.github.com/repos/flutter/flutter/compare/${flutterVersion}...${flutterVersion} /dev/null
 
-RUN git clone https://github.com/flutter/flutter.git -b ${flutterVersion} flutter-sdk --depth 1 
+RUN git clone https://github.com/flutter/flutter.git -b ${flutterVersion} flutter-sdk
 
 RUN flutter-sdk/bin/flutter precache
 

--- a/Dockerfile.tags
+++ b/Dockerfile.tags
@@ -9,11 +9,11 @@ ARG flutterVersion=stable
 
 ADD https://api.github.com/repos/flutter/flutter/compare/${flutterVersion}...${flutterVersion} /dev/null
 
-RUN git clone https://github.com/flutter/flutter.git -b ${flutterVersion} /flutter --depth 1 
+RUN git clone https://github.com/flutter/flutter.git -b ${flutterVersion} /flutter
 
-RUN if [ -f "/flutter/bin/dart"]; then /flutter/bin/flutter; fi 
+RUN if [ -f "/flutter/bin/dart"]; then /flutter/bin/flutter; fi
 
 ENV PATH="$PATH:/flutter/bin"
 ENV PATH="$PATH:/flutter/bin/cache/dart-sdk/bin"
 
-RUN if [ -f "/flutter/bin/dart"]; then flutter doctor; fi 
+RUN if [ -f "/flutter/bin/dart"]; then flutter doctor; fi


### PR DESCRIPTION
Close #5.

https://github.com/flutter/flutter/issues/24956#issuecomment-570286127. Flutter relies on tags to resolve its version. Cloning with `--depth 1` is known to cause `0.0.0-unknown` version issue.